### PR TITLE
doc: timeout must be greater than 1000

### DIFF
--- a/ipmi_remote.yml
+++ b/ipmi_remote.yml
@@ -20,6 +20,7 @@ modules:
                 # The session timeout is in milliseconds. Note that a scrape can take up
                 # to (session-timeout * #-of-collectors) milliseconds, so set the scrape
                 # timeout in Prometheus accordingly.
+                # Must be larger than the retransmission timeout, which defaults to 1000.
                 timeout: 10000
                 # Available collectors are bmc, ipmi, chassis, dcmi, sel, and sm-lan-mode
                 # If _not_ specified, bmc, ipmi, chassis, and dcmi are used


### PR DESCRIPTION
I just had an issue, where the dcmi collector returned:
```
ipmi_ctx_open_outofband_2_0: invalid parameters
```

It was because I set the timeout to `1000`, but this was too low since it has to be greater than `retransmission-timeout` which defaults to 1000:
https://www.gnu.org/software/freeipmi/manpages/man8/ipmi-dcmi.8.html

This PR documents this configuration subtlety 