### PR TITLE
fix unsupported value type in debug logs due to attempting to log structs directly

### DIFF
--- a/collector_ipmi.go
+++ b/collector_ipmi.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"fmt"
 	"math"
 	"strconv"
 
@@ -158,7 +159,7 @@ func (c IPMICollector) Collect(result freeipmi.Result, ch chan<- prometheus.Metr
 			state = math.NaN()
 		}
 
-		level.Debug(logger).Log("msg", "Got values", "data", data)
+		level.Debug(logger).Log("msg", "Got values", "data", fmt.Sprintf("%+v", data))
 
 		switch data.Unit {
 		case "RPM":

--- a/freeipmi/freeipmi.go
+++ b/freeipmi/freeipmi.go
@@ -136,7 +136,7 @@ func Execute(cmd string, args []string, config string, target string, logger log
 		target = "[local]"
 	}
 
-	level.Debug(logger).Log("msg", "Executing", "command", cmd, "args", args)
+	level.Debug(logger).Log("msg", "Executing", "command", cmd, "args", fmt.Sprintf("%+v", args))
 	out, err := exec.Command(cmd, args...).CombinedOutput()
 	if err != nil {
 		err = fmt.Errorf("error running %s: %s", cmd, err)


### PR DESCRIPTION
Instead of this:
```
level=debug ts=2021-11-09T05:12:58.244Z caller=freeipmi.go:139 msg=Executing command=ipmimonitoring args="unsupported value type"
level=debug ts=2021-11-09T05:12:58.475Z caller=collector_ipmi.go:161 msg="Got values" data="unsupported value type"
```
You get this now:
```
level=debug ts=2021-11-09T05:41:58.307Z caller=freeipmi.go:139 msg=Executing command=ipmimonitoring args="[--entity-sensor-names --record-ids=<...> -Q --ignore-unrecognized-events --comma-separated-output --no-header-output --sdr-cache-recreate --output-event-bitmask --config-file <...> -h <...>]"
level=debug ts=2021-11-09T05:41:58.542Z caller=collector_ipmi.go:162 msg="Got values" data="{ID:91 Name:Power Supply 1 Current 1 Type:Current State:Nominal Value:1.4 Unit:A Event:00C0h}"
```