### PR TITLE
Add support for fan sensors which report as a percentage

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -111,13 +111,19 @@ sensor ID and the sensor name as labels. Example:
 
 ### Fan speed sensors
 
-Fan speed sensors measure fan speed in rotations per minute (RPM) and their
-state usually reflects the speed being to low, indicating the fan might be
-broken. For each fan speed sensor, two metrics are exported (state and value),
-using the sensor ID and the sensor name as labels. Example:
+Fan speed sensors measure fan speed in rotations per minute (RPM) or as a
+percentage of the maximum speed, and their state usually reflects the speed
+being to low, indicating the fan might be broken. For each fan speed sensor,
+two metrics are exported (state and value), using the sensor ID and the
+sensor name as labels. Example:
 
     ipmi_fan_speed_rpm{id="12",name="Fan1A"} 4560
     ipmi_fan_speed_state{id="12",name="Fan1A"} 0
+
+or, for a percentage based fan:
+
+    ipmi_fan_speed_ratio{id="58",name="Fan 1 DutyCycle"} 0.2195
+    ipmi_fan_speed_state{id="58",name="Fan 1 DutyCycle"} 0
 
 ### Voltage sensors
 


### PR DESCRIPTION
Fan sensors on HP servers report speed as a percentage of the maximum instead of a raw RPM value, for example:

```
% sudo ipmi-sensors --sensor-types=Fan
ID | Name            | Type | Reading    | Units | Event
57 | Fan 1           | Fan  | N/A        | N/A   | 'transition to Running'
58 | Fan 1 DutyCycle | Fan  | 21.95      | %     | 'OK'
59 | Fan 1 Presence  | Fan  | N/A        | N/A   | 'Device Inserted/Device Present'
60 | Fan 2           | Fan  | N/A        | N/A   | 'transition to Running'
61 | Fan 2 DutyCycle | Fan  | 27.83      | %     | 'OK'
62 | Fan 2 Presence  | Fan  | N/A        | N/A   | 'Device Inserted/Device Present'
63 | Fan 3           | Fan  | N/A        | N/A   | 'transition to Running'
64 | Fan 3 DutyCycle | Fan  | 27.83      | %     | 'OK'
65 | Fan 3 Presence  | Fan  | N/A        | N/A   | 'Device Inserted/Device Present'
66 | Fan 4           | Fan  | N/A        | N/A   | 'transition to Running'
67 | Fan 4 DutyCycle | Fan  | 21.95      | %     | 'OK'
68 | Fan 4 Presence  | Fan  | N/A        | N/A   | 'Device Inserted/Device Present'
69 | Fan 5           | Fan  | N/A        | N/A   | 'transition to Running'
70 | Fan 5 DutyCycle | Fan  | 21.95      | %     | 'OK'
71 | Fan 5 Presence  | Fan  | N/A        | N/A   | 'Device Inserted/Device Present'
72 | Fan 6           | Fan  | N/A        | N/A   | 'transition to Running'
73 | Fan 6 DutyCycle | Fan  | 27.44      | %     | 'OK'
74 | Fan 6 Presence  | Fan  | N/A        | N/A   | 'Device Inserted/Device Present'
75 | Fan 7           | Fan  | N/A        | N/A   | 'transition to Running'
76 | Fan 7 DutyCycle | Fan  | 27.44      | %     | 'OK'
77 | Fan 7 Presence  | Fan  | N/A        | N/A   | 'Device Inserted/Device Present'
88 | Fans            | Fan  | N/A        | N/A   | 'Fully Redundant'
```

This adds support for those sensors, scaling them to a ratio between 0 and 1 and reporting them as a new `ipmi_fan_speed_ratio` metric.