### PR TITLE
Added target to debug logs

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -97,7 +97,7 @@ func (c metaCollector) Collect(ch chan<- prometheus.Metric) {
 
 	for _, collector := range config.GetCollectors() {
 		var up int
-		_ = level.Debug(logger).Log("msg", "Running collector", "collector", collector.Name())
+		_ = level.Debug(logger).Log("msg", "Running collector", "target", target.host, "collector", collector.Name())
 
 		fqcmd := path.Join(*executablesPath, collector.Cmd())
 		args := collector.Args()

--- a/collector_ipmi.go
+++ b/collector_ipmi.go
@@ -144,9 +144,10 @@ func (c IPMICollector) Args() []string {
 
 func (c IPMICollector) Collect(result freeipmi.Result, ch chan<- prometheus.Metric, target ipmiTarget) (int, error) {
 	excludeIds := target.config.ExcludeSensorIDs
+	targetHost := targetName(target.host)
 	results, err := freeipmi.GetSensorData(result, excludeIds)
 	if err != nil {
-		_ = level.Error(logger).Log("msg", "Failed to collect sensor data", "target", targetName(target.host), "error", err)
+		_ = level.Error(logger).Log("msg", "Failed to collect sensor data", "target", targetHost, "error", err)
 		return 0, err
 	}
 	for _, data := range results {
@@ -162,11 +163,11 @@ func (c IPMICollector) Collect(result freeipmi.Result, ch chan<- prometheus.Metr
 		case "N/A":
 			state = math.NaN()
 		default:
-			_ = level.Error(logger).Log("msg", "Unknown sensor state", "state", data.State)
+			_ = level.Error(logger).Log("msg", "Unknown sensor state", "target", targetHost, "state", data.State)
 			state = math.NaN()
 		}
 
-		_ = level.Debug(logger).Log("msg", "Got values", "data", fmt.Sprintf("%+v", data))
+		_ = level.Debug(logger).Log("msg", "Got values", "target", targetHost, "data", fmt.Sprintf("%+v", data))
 
 		switch data.Unit {
 		case "RPM":


### PR DESCRIPTION
When we need to debug special target on exporter among dozens of hosts - target is necessary for greps