### PR TITLE
Add `--output-sensor-state` argument to ipmi-sensors command

### DIFF
--- a/collector_ipmi.go
+++ b/collector_ipmi.go
@@ -139,6 +139,7 @@ func (c IPMICollector) Args() []string {
 		"--no-header-output",
 		"--sdr-cache-recreate",
 		"--output-event-bitmask",
+		"--output-sensor-state",
 	}
 }
 


### PR DESCRIPTION
I received an error collection ipmi sensors status, because my output table is missing status column. It can be added by the argument according to `--help` information.