### PR TITLE
Added Power Measurement State to DCMI collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## next
+
+* Now, `ipmi_dcmi_power_consumption_watts` metric is not present if Power
+Measurement feature is not present. Before this change - the value was zero
+
 ## 1.6.1 / 2022-06-17
 
 * Another "I screwed up the release" release

--- a/collector_dcmi.go
+++ b/collector_dcmi.go
@@ -53,10 +53,13 @@ func (c DCMICollector) Collect(result freeipmi.Result, ch chan<- prometheus.Metr
 		level.Error(logger).Log("msg", "Failed to collect DCMI data", "target", targetName(target.host), "error", err)
 		return 0, err
 	}
-	ch <- prometheus.MustNewConstMetric(
-		powerConsumptionDesc,
-		prometheus.GaugeValue,
-		currentPowerConsumption,
-	)
+	// Returned value negative == Power Measurement is not avail
+	if currentPowerConsumption > -1 {
+		ch <- prometheus.MustNewConstMetric(
+			powerConsumptionDesc,
+			prometheus.GaugeValue,
+			currentPowerConsumption,
+		)
+	}
 	return 1, nil
 }

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -41,7 +41,7 @@ case it will be exported as `"N/A"`.
 This metric is only provided if the `chassis` collector is enabled.
 
 The metric `ipmi_chassis_power_state` shows the current chassis power state of
-the machine.  The value is 1 for power on, and 0 otherwise.
+the machine. The value is 1 for power on, and 0 otherwise.
 
 ## Power consumption
 
@@ -159,7 +159,7 @@ explicit [power consumption metrics](#power_consumption) for this.
 ### Generic sensors
 
 For all sensors that can not be classified, two generic metrics are exported,
-the state and the value.  However, to provide a little more context, the sensor
+the state and the value. However, to provide a little more context, the sensor
 type is added as label (in addition to name and ID). Example:
 
     ipmi_sensor_state{id="139",name="Power Cable",type="Cable/Interconnect"} 0


### PR DESCRIPTION
Added DCMI metric to definitely determine avail of Power Measurement feature

In some cases, for example with cheap Power Supply Units power consumption may be not available at all, to control this added `ipmi_dcmi_power_measurement_state` metric. The value is `1` for power measure is available on, and `0` otherwise.

The main point for this changes is a try to knowledge: the measurements isn't accessed due PSU broken (FW/cable/etc issues) or not avail at all on system level (and system know about that) 

The host with "normal PSU":
```ruby
root@host# curl -Ss "http://127.0.0.1:9291/ipmi?module=default&target=10.249.0.9" | grep -i dcmi
# HELP ipmi_dcmi_power_consumption_watts Current power consumption in Watts.
# TYPE ipmi_dcmi_power_consumption_watts gauge
ipmi_dcmi_power_consumption_watts 353
# HELP ipmi_dcmi_power_measurement_state Availability of Power Measurement (0=false, 1=true).
# TYPE ipmi_dcmi_power_measurement_state gauge
ipmi_dcmi_power_measurement_state 1
ipmi_up{collector="dcmi"} 1
```
The host with "strange PSU's"
```ruby
root@host# curl -Ss "http://127.0.0.1:9291/ipmi?module=default&target=10.249.0.6" | grep -i dcmi
# HELP ipmi_dcmi_power_consumption_watts Current power consumption in Watts.
# TYPE ipmi_dcmi_power_consumption_watts gauge
ipmi_dcmi_power_consumption_watts 0
# HELP ipmi_dcmi_power_measurement_state Availability of Power Measurement (0=false, 1=true).
# TYPE ipmi_dcmi_power_measurement_state gauge
ipmi_dcmi_power_measurement_state 0
ipmi_up{collector="dcmi"} 1
```