### PR TITLE
fix: correct issue after run gosec

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -30,3 +30,16 @@ jobs:
         uses: golangci/golangci-lint-action@v3.4.0
         with:
           version: v1.53.3
+
+  gosec:
+    name: gosec
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v3
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          args: ./...

--- a/collector.go
+++ b/collector.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"fmt"
 	"path"
 	"time"
 
@@ -81,7 +82,10 @@ func (c metaCollector) Collect(ch chan<- prometheus.Metric) {
 	start := time.Now()
 	defer func() {
 		duration := time.Since(start).Seconds()
-		level.Debug(logger).Log("msg", "Scrape duration", "target", targetName(c.target), "duration", duration)
+		e := level.Debug(logger).Log("msg", "Scrape duration", "target", targetName(c.target), "duration", duration)
+		if e != nil {
+			fmt.Println(e)
+		}
 		ch <- prometheus.MustNewConstMetric(
 			durationDesc,
 			prometheus.GaugeValue,
@@ -97,7 +101,10 @@ func (c metaCollector) Collect(ch chan<- prometheus.Metric) {
 
 	for _, collector := range config.GetCollectors() {
 		var up int
-		level.Debug(logger).Log("msg", "Running collector", "target", target.host, "collector", collector.Name())
+		e := level.Debug(logger).Log("msg", "Running collector", "target", target.host, "collector", collector.Name())
+		if e != nil {
+			fmt.Println(e)
+		}
 
 		fqcmd := path.Join(*executablesPath, collector.Cmd())
 		args := collector.Args()

--- a/collector_bmc.go
+++ b/collector_bmc.go
@@ -14,6 +14,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -50,18 +52,27 @@ func (c BMCCollector) Args() []string {
 func (c BMCCollector) Collect(result freeipmi.Result, ch chan<- prometheus.Metric, target ipmiTarget) (int, error) {
 	firmwareRevision, err := freeipmi.GetBMCInfoFirmwareRevision(result)
 	if err != nil {
-		level.Error(logger).Log("msg", "Failed to collect BMC data", "target", targetName(target.host), "error", err)
+		e := level.Error(logger).Log("msg", "Failed to collect BMC data", "target", targetName(target.host), "error", err)
+		if e != nil {
+			fmt.Println(e)
+		}
 		return 0, err
 	}
 	manufacturerID, err := freeipmi.GetBMCInfoManufacturerID(result)
 	if err != nil {
-		level.Error(logger).Log("msg", "Failed to collect BMC data", "target", targetName(target.host), "error", err)
+		e := level.Error(logger).Log("msg", "Failed to collect BMC data", "target", targetName(target.host), "error", err)
+		if e != nil {
+			fmt.Println(e)
+		}
 		return 0, err
 	}
 	systemFirmwareVersion, err := freeipmi.GetBMCInfoSystemFirmwareVersion(result)
 	if err != nil {
 		// This one is not always available.
-		level.Debug(logger).Log("msg", "Failed to parse bmc-info data", "target", targetName(target.host), "error", err)
+		e := level.Debug(logger).Log("msg", "Failed to parse bmc-info data", "target", targetName(target.host), "error", err)
+		if e != nil {
+			fmt.Println(e)
+		}
 		systemFirmwareVersion = "N/A"
 	}
 	ch <- prometheus.MustNewConstMetric(

--- a/collector_chassis.go
+++ b/collector_chassis.go
@@ -14,6 +14,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -62,17 +64,26 @@ func (c ChassisCollector) Args() []string {
 func (c ChassisCollector) Collect(result freeipmi.Result, ch chan<- prometheus.Metric, target ipmiTarget) (int, error) {
 	currentChassisPowerState, err := freeipmi.GetChassisPowerState(result)
 	if err != nil {
-		level.Error(logger).Log("msg", "Failed to collect chassis data", "target", targetName(target.host), "error", err)
+		e := level.Error(logger).Log("msg", "Failed to collect chassis data", "target", targetName(target.host), "error", err)
+		if e != nil {
+			fmt.Println(e)
+		}
 		return 0, err
 	}
 	currentChassisDriveFault, err := freeipmi.GetChassisDriveFault(result)
 	if err != nil {
-		level.Error(logger).Log("msg", "Failed to collect chassis data", "target", targetName(target.host), "error", err)
+		e := level.Error(logger).Log("msg", "Failed to collect chassis data", "target", targetName(target.host), "error", err)
+		if e != nil {
+			fmt.Println(e)
+		}
 		return 0, err
 	}
 	currentChassisCoolingFault, err := freeipmi.GetChassisCoolingFault(result)
 	if err != nil {
-		level.Error(logger).Log("msg", "Failed to collect chassis data", "target", targetName(target.host), "error", err)
+		e := level.Error(logger).Log("msg", "Failed to collect chassis data", "target", targetName(target.host), "error", err)
+		if e != nil {
+			fmt.Println(e)
+		}
 		return 0, err
 	}
 	ch <- prometheus.MustNewConstMetric(

--- a/collector_dcmi.go
+++ b/collector_dcmi.go
@@ -14,6 +14,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -50,7 +52,10 @@ func (c DCMICollector) Args() []string {
 func (c DCMICollector) Collect(result freeipmi.Result, ch chan<- prometheus.Metric, target ipmiTarget) (int, error) {
 	currentPowerConsumption, err := freeipmi.GetCurrentPowerConsumption(result)
 	if err != nil {
-		level.Error(logger).Log("msg", "Failed to collect DCMI data", "target", targetName(target.host), "error", err)
+		e := level.Error(logger).Log("msg", "Failed to collect DCMI data", "target", targetName(target.host), "error", err)
+		if e != nil {
+			fmt.Println(e)
+		}
 		return 0, err
 	}
 	// Returned value negative == Power Measurement is not avail

--- a/collector_ipmi.go
+++ b/collector_ipmi.go
@@ -148,7 +148,10 @@ func (c IPMICollector) Collect(result freeipmi.Result, ch chan<- prometheus.Metr
 	targetHost := targetName(target.host)
 	results, err := freeipmi.GetSensorData(result, excludeIds)
 	if err != nil {
-		level.Error(logger).Log("msg", "Failed to collect sensor data", "target", targetHost, "error", err)
+		e := level.Error(logger).Log("msg", "Failed to collect sensor data", "target", targetHost, "error", err)
+		if e != nil {
+			fmt.Println(e)
+		}
 		return 0, err
 	}
 	for _, data := range results {
@@ -164,11 +167,17 @@ func (c IPMICollector) Collect(result freeipmi.Result, ch chan<- prometheus.Metr
 		case "N/A":
 			state = math.NaN()
 		default:
-			level.Error(logger).Log("msg", "Unknown sensor state", "target", targetHost, "state", data.State)
+			e := level.Error(logger).Log("msg", "Unknown sensor state", "target", targetHost, "state", data.State)
+			if e != nil {
+				fmt.Println(e)
+			}
 			state = math.NaN()
 		}
 
-		level.Debug(logger).Log("msg", "Got values", "target", targetHost, "data", fmt.Sprintf("%+v", data))
+		e := level.Debug(logger).Log("msg", "Got values", "target", targetHost, "data", fmt.Sprintf("%+v", data))
+		if e != nil {
+			fmt.Println(e)
+		}
 
 		switch data.Unit {
 		case "RPM":

--- a/collector_sel.go
+++ b/collector_sel.go
@@ -14,6 +14,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -57,12 +59,18 @@ func (c SELCollector) Args() []string {
 func (c SELCollector) Collect(result freeipmi.Result, ch chan<- prometheus.Metric, target ipmiTarget) (int, error) {
 	entriesCount, err := freeipmi.GetSELInfoEntriesCount(result)
 	if err != nil {
-		level.Error(logger).Log("msg", "Failed to collect SEL data", "target", targetName(target.host), "error", err)
+		e := level.Error(logger).Log("msg", "Failed to collect SEL data", "target", targetName(target.host), "error", err)
+		if e != nil {
+			fmt.Println(e)
+		}
 		return 0, err
 	}
 	freeSpace, err := freeipmi.GetSELInfoFreeSpace(result)
 	if err != nil {
-		level.Error(logger).Log("msg", "Failed to collect SEL data", "target", targetName(target.host), "error", err)
+		e := level.Error(logger).Log("msg", "Failed to collect SEL data", "target", targetName(target.host), "error", err)
+		if e != nil {
+			fmt.Println(e)
+		}
 		return 0, err
 	}
 	ch <- prometheus.MustNewConstMetric(

--- a/collector_sm_lan_mode.go
+++ b/collector_sm_lan_mode.go
@@ -53,11 +53,17 @@ func (c SMLANModeCollector) Args() []string {
 func (c SMLANModeCollector) Collect(result freeipmi.Result, ch chan<- prometheus.Metric, target ipmiTarget) (int, error) {
 	octets, err := freeipmi.GetRawOctets(result)
 	if err != nil {
-		level.Error(logger).Log("msg", "Failed to collect LAN mode data", "target", targetName(target.host), "error", err)
+		e := level.Error(logger).Log("msg", "Failed to collect LAN mode data", "target", targetName(target.host), "error", err)
+		if e != nil {
+			fmt.Println(e)
+		}
 		return 0, err
 	}
 	if len(octets) != 3 {
-		level.Error(logger).Log("msg", "Unexpected number of octets", "target", targetName(target.host), "octets", octets)
+		e := level.Error(logger).Log("msg", "Unexpected number of octets", "target", targetName(target.host), "octets", octets)
+		if e != nil {
+			fmt.Println(e)
+		}
 		return 0, fmt.Errorf("unexpected number of octets in raw response: %d", len(octets))
 	}
 
@@ -66,7 +72,10 @@ func (c SMLANModeCollector) Collect(result freeipmi.Result, ch chan<- prometheus
 		value, _ := strconv.Atoi(octets[2])
 		ch <- prometheus.MustNewConstMetric(lanModeDesc, prometheus.GaugeValue, float64(value))
 	default:
-		level.Error(logger).Log("msg", "Unexpected lan mode status (ipmi-raw)", "target", targetName(target.host), "sgatus", octets[2])
+		e := level.Error(logger).Log("msg", "Unexpected lan mode status (ipmi-raw)", "target", targetName(target.host), "sgatus", octets[2])
+		if e != nil {
+			fmt.Println(e)
+		}
 		return 0, fmt.Errorf("unexpected lan mode status: %s", octets[2])
 	}
 

--- a/config.go
+++ b/config.go
@@ -15,7 +15,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -223,7 +223,7 @@ func (sc *SafeConfig) ReloadConfig(configFile string) error {
 	var err error
 
 	if configFile != "" {
-		config, err = ioutil.ReadFile(filepath.Clean(configFile))
+		config, err = os.ReadFile(filepath.Clean(configFile))
 		if err != nil {
 			e := level.Error(logger).Log("msg", "Error reading config file", "error", err)
 			if e != nil {

--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -222,7 +223,7 @@ func (sc *SafeConfig) ReloadConfig(configFile string) error {
 	var err error
 
 	if configFile != "" {
-		config, err = ioutil.ReadFile(configFile)
+		config, err = ioutil.ReadFile(filepath.Clean(configFile))
 		if err != nil {
 			level.Error(logger).Log("msg", "Error reading config file", "error", err)
 			return err

--- a/config.go
+++ b/config.go
@@ -225,7 +225,10 @@ func (sc *SafeConfig) ReloadConfig(configFile string) error {
 	if configFile != "" {
 		config, err = ioutil.ReadFile(filepath.Clean(configFile))
 		if err != nil {
-			level.Error(logger).Log("msg", "Error reading config file", "error", err)
+			e := level.Error(logger).Log("msg", "Error reading config file", "error", err)
+			if e != nil {
+				fmt.Println(e)
+			}
 			return err
 		}
 	} else {
@@ -241,7 +244,10 @@ func (sc *SafeConfig) ReloadConfig(configFile string) error {
 	sc.Unlock()
 
 	if configFile != "" {
-		level.Info(logger).Log("msg", "Loaded config file", "path", configFile)
+		e := level.Info(logger).Log("msg", "Loaded config file", "path", configFile)
+		if e != nil {
+			fmt.Println(e)
+		}
 	}
 	return nil
 }
@@ -267,7 +273,10 @@ func (sc *SafeConfig) ConfigForTarget(target, module string) IPMIConfig {
 	if module != "default" {
 		config, ok = sc.C.Modules[module]
 		if !ok {
-			level.Error(logger).Log("msg", "Requested module not found, using default", "module", module, "target", targetName(target))
+			e := level.Error(logger).Log("msg", "Requested module not found, using default", "module", module, "target", targetName(target))
+			if e != nil {
+				fmt.Println(e)
+			}
 		}
 	}
 
@@ -276,7 +285,10 @@ func (sc *SafeConfig) ConfigForTarget(target, module string) IPMIConfig {
 		config, ok = sc.C.Modules["default"]
 		if !ok {
 			// This is probably fine for running locally, so not making this a warning
-			level.Debug(logger).Log("msg", "Needed default config for, but none configured, using FreeIPMI defaults", "target", targetName(target))
+			e := level.Debug(logger).Log("msg", "Needed default config for, but none configured, using FreeIPMI defaults", "target", targetName(target))
+			if e != nil {
+				fmt.Println(e)
+			}
 			config = defaultConfig
 		}
 	}

--- a/freeipmi/freeipmi.go
+++ b/freeipmi/freeipmi.go
@@ -115,7 +115,7 @@ func freeipmiConfigPipe(config string, logger log.Logger) (string, error) {
 	}
 
 	go func(file string, data []byte) {
-		f, err := os.OpenFile(file, os.O_WRONLY|os.O_CREATE|os.O_APPEND, os.ModeNamedPipe)
+		f, err := os.OpenFile(filepath.Clean(file), os.O_WRONLY|os.O_CREATE|os.O_APPEND, os.ModeNamedPipe)
 		if err != nil {
 			level.Error(logger).Log("msg", "Error opening pipe", "error", err)
 		}

--- a/freeipmi/freeipmi.go
+++ b/freeipmi/freeipmi.go
@@ -117,12 +117,18 @@ func freeipmiConfigPipe(config string, logger log.Logger) (string, error) {
 	go func(file string, data []byte) {
 		f, err := os.OpenFile(filepath.Clean(file), os.O_WRONLY|os.O_CREATE|os.O_APPEND, os.ModeNamedPipe)
 		if err != nil {
-			level.Error(logger).Log("msg", "Error opening pipe", "error", err)
+			e := level.Error(logger).Log("msg", "Error opening pipe", "error", err)
+			if e != nil {
+				fmt.Println(e)
+			}
 		}
 		if _, err := f.Write(data); err != nil {
-			level.Error(logger).Log("msg", "Error writing config to pipe", "error", err)
+			e := level.Error(logger).Log("msg", "Error writing config to pipe", "error", err)
+			if e != nil {
+				fmt.Println(e)
+			}
 		}
-		f.Close()
+		defer f.Close()
 	}(pipe, content)
 	return pipe, nil
 }
@@ -134,7 +140,10 @@ func Execute(cmd string, args []string, config string, target string, logger log
 	}
 	defer func() {
 		if err := os.Remove(pipe); err != nil {
-			level.Error(logger).Log("msg", "Error deleting named pipe", "error", err)
+			e := level.Error(logger).Log("msg", "Error deleting named pipe", "error", err)
+			if e != nil {
+				fmt.Println(e)
+			}
 		}
 	}()
 
@@ -143,7 +152,10 @@ func Execute(cmd string, args []string, config string, target string, logger log
 		args = append(args, "-h", target)
 	}
 
-	level.Debug(logger).Log("msg", "Executing", "command", cmd, "args", fmt.Sprintf("%+v", args))
+	e := level.Debug(logger).Log("msg", "Executing", "command", cmd, "args", fmt.Sprintf("%+v", args))
+	if e != nil {
+		fmt.Println(e)
+	}
 	out, err := exec.Command(cmd, args...).CombinedOutput()
 	if err != nil {
 		err = fmt.Errorf("error running %s: %s", cmd, err)

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	kingpin "github.com/alecthomas/kingpin/v2"
 	"github.com/go-kit/log"
@@ -165,7 +166,9 @@ func main() {
             </html>`))
 	})
 
-	srv := &http.Server{}
+	srv := &http.Server{
+		ReadHeaderTimeout: 2 * time.Second, // Fix CWE-400 Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server
+	}
 	if err := web.ListenAndServe(srv, webConfig, logger); err != nil {
 		level.Error(logger).Log("msg", "HTTP listener stopped", "error", err)
 		os.Exit(1)


### PR DESCRIPTION
# Context

To improve security, we ran the gosec lint to check for potential security holes in the project.

gosec : https://securego.io/docs/rules/rule-intro 

# Fix 

[x] G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
[x] G304 (CWE-22): Potential file inclusion via variable (Confidence: HIGH, Severity: MEDIUM)
[x] G112 (CWE-400): Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server (Confidence: LOW, Severity: MEDIUM)

# Change

- Remove deprecated dependencies "io/ioutils"
-  Add gosec job in github pipeline.