### PR TITLE
fix: bring back aarch64 builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH="amd64"
 ARG OS="linux"
-FROM alpine:3
+FROM --platform=${OS}/${ARCH} alpine:3
 RUN apk --no-cache add freeipmi
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,7 @@
 .PHONY: all
 all: precheck style unused build test
 
-#DOCKER_ARCHS      ?= amd64 arm64
-DOCKER_ARCHS      ?= amd64
+DOCKER_ARCHS      ?= amd64 arm64
 DOCKER_IMAGE_NAME ?= ipmi-exporter
 DOCKER_REPO       ?= prometheuscommunity
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ executable in `$GOPATH/bin`:
 You can build a Docker container with the included `docker` make target:
 
     make promu
-    promu crossbuild -p linux/amd64
+    promu crossbuild -p linux/amd64 -p linux/arm64
     make docker
 
 This will not even require Go tooling on the host. See the included [docker


### PR DESCRIPTION
This is a pretty trivial fix to bring back arm64
builds and this has been tested locally as well.

Closes: #103 