### PR TITLE
feat: add bmc url

### DIFF
--- a/collector_bmc.go
+++ b/collector_bmc.go
@@ -27,7 +27,7 @@ var (
 	bmcInfoDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "bmc", "info"),
 		"Constant metric with value '1' providing details about the BMC.",
-		[]string{"firmware_revision", "manufacturer_id", "system_firmware_version"},
+		[]string{"firmware_revision", "manufacturer_id", "system_firmware_version", "bmc_url"},
 		nil,
 	)
 )
@@ -63,11 +63,17 @@ func (c BMCCollector) Collect(result freeipmi.Result, ch chan<- prometheus.Metri
 		logger.Debug("Failed to parse bmc-info data", "target", targetName(target.host), "error", err)
 		systemFirmwareVersion = "N/A"
 	}
+	bmcUrl, err := freeipmi.GetBMCInfoBmcUrl(result)
+	if err != nil {
+		// This one is not always available.
+		logger.Debug("Failed to parse bmc-info data", "target", targetName(target.host), "error", err)
+		systemFirmwareVersion = "N/A"
+	}
 	ch <- prometheus.MustNewConstMetric(
 		bmcInfoDesc,
 		prometheus.GaugeValue,
 		1,
-		firmwareRevision, manufacturerID, systemFirmwareVersion,
+		firmwareRevision, manufacturerID, systemFirmwareVersion, bmcUrl
 	)
 	return 1, nil
 }

--- a/collector_bmc.go
+++ b/collector_bmc.go
@@ -73,7 +73,7 @@ func (c BMCCollector) Collect(result freeipmi.Result, ch chan<- prometheus.Metri
 		bmcInfoDesc,
 		prometheus.GaugeValue,
 		1,
-		firmwareRevision, manufacturerID, systemFirmwareVersion, bmcUrl
+		firmwareRevision, manufacturerID, systemFirmwareVersion, bmcUrl,
 	)
 	return 1, nil
 }

--- a/collector_bmc.go
+++ b/collector_bmc.go
@@ -67,7 +67,7 @@ func (c BMCCollector) Collect(result freeipmi.Result, ch chan<- prometheus.Metri
 	if err != nil {
 		// This one is not always available.
 		logger.Debug("Failed to parse bmc-info data", "target", targetName(target.host), "error", err)
-		systemFirmwareVersion = "N/A"
+		bmcUrl = "N/A"
 	}
 	ch <- prometheus.MustNewConstMetric(
 		bmcInfoDesc,

--- a/freeipmi/freeipmi.go
+++ b/freeipmi/freeipmi.go
@@ -43,6 +43,7 @@ var (
 	bmcInfoFirmwareRevisionRegex        = regexp.MustCompile(`^Firmware Revision\s*:\s*(?P<value>[0-9.]*).*`)
 	bmcInfoSystemFirmwareVersionRegex   = regexp.MustCompile(`^System Firmware Version\s*:\s*(?P<value>[0-9.]*).*`)
 	bmcInfoManufacturerIDRegex          = regexp.MustCompile(`^Manufacturer ID\s*:\s*(?P<value>.*)`)
+	bmcInfoBmcUrlRegex                  = regexp.MustCompile(`^BMC URL\s*:\s*(?P<value>.*)`)
 	bmcWatchdogTimerStateRegex          = regexp.MustCompile(`^Timer:\s*(?P<value>Running|Stopped)`)
 	bmcWatchdogTimerUseRegex            = regexp.MustCompile(`^Timer Use:\s*(?P<value>.*)`)
 	bmcWatchdogTimerLoggingRegex        = regexp.MustCompile(`^Logging:\s*(?P<value>Enabled|Disabled)`)
@@ -311,6 +312,13 @@ func GetBMCInfoSystemFirmwareVersion(ipmiOutput Result) (string, error) {
 		return "", fmt.Errorf("%s: %s", ipmiOutput.err, ipmiOutput.output)
 	}
 	return getValue(ipmiOutput.output, bmcInfoSystemFirmwareVersionRegex)
+}
+
+func GetBMCInfoBmcUrl(ipmiOutput Result) (string, error) {
+	if ipmiOutput.err != nil {
+		return "", fmt.Errorf("%s: %s", ipmiOutput.err, ipmiOutput.output)
+	}
+	return getValue(ipmiOutput.output, bmcInfoBmcUrlRegex)
 }
 
 func GetSELInfoEntriesCount(ipmiOutput Result) (float64, error) {


### PR DESCRIPTION
@SuperQ Hi!
Please review the PR. I need to add URL info from BMC.

Actual output from console

```bash
# bmc-info | egrep "^BMC URL\s*:\s*(.*)"
BMC URL                       : https://123.234.21.231:443
```