### PR TITLE
Use long option for quiet cache

### DIFF
--- a/collector_ipmi.go
+++ b/collector_ipmi.go
@@ -132,7 +132,7 @@ func (c IPMICollector) Cmd() string {
 
 func (c IPMICollector) Args() []string {
 	return []string{
-		"-Q",
+		"--quiet-cache",
 		"--ignore-unrecognized-events",
 		"--comma-separated-output",
 		"--no-header-output",

--- a/collector_sel_events.go
+++ b/collector_sel_events.go
@@ -59,7 +59,7 @@ func (c SELEventsCollector) Cmd() string {
 
 func (c SELEventsCollector) Args() []string {
 	return []string{
-		"-Q",
+		"--quiet-cache",
 		"--comma-separated-output",
 		"--no-header-output",
 		"--sdr-cache-recreate",


### PR DESCRIPTION
Hi, FreeIPMI maintainer here.  A user reported a potential issue with the FreeIPMI master branch.    I don't use prometheus so this fix is going off code inspection only and is untested.

---

Problem: The short option -Q for "quiet cache" was legacied in FreeIPMI in early 2018.  It has the potential to be removed some day in the future.

Solution: Use the long option --quiet-cache instead.
