### PR TITLE
Replace codespell with misspell

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,13 +16,6 @@ jobs:
       - run: make
       - prometheus/store_artifact:
           file: ipmi_exporter
-  codespell:
-    docker:
-      - image: circleci/python
-    steps:
-      - checkout
-      - run: sudo pip install codespell
-      - run: codespell --skip=".git,./vendor,ttar,go.mod,go.sum,*pem" -L uint,packages\',uptodate
 workflows:
   version: 2
   ipmi_exporter:
@@ -33,10 +26,6 @@ workflows:
               only: /.*/
       - prometheus/build:
           name: build
-          filters:
-            tags:
-              only: /.*/
-      - codespell:
           filters:
             tags:
               only: /.*/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 ---
 linters:
   enable:
+    - misspell
     - sloglint
 
 issues:


### PR DESCRIPTION
Use golangci-lint misspell plugin instead of separate codespell CI pipeline.