### PR TITLE
add the Version Collector Metric

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 
 	kingpin "github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"
+	versioncollector "github.com/prometheus/client_golang/prometheus/collectors/version"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/promslog"
 	"github.com/prometheus/common/promslog/flag"
@@ -128,6 +129,7 @@ func main() {
 		}
 	}()
 
+	prometheus.MustRegister(versioncollector.NewCollector("ipmi_exporter"))
 	localCollector := metaCollector{target: targetLocal, module: "default", config: sc}
 	prometheus.MustRegister(&localCollector)
 


### PR DESCRIPTION
To find out which version of the IPMI Exporter is running, add the VersionCollector from the Prometheus Golang Client.

We use the build info metrics to see if our maintained exporters need updates. The metric was lacking, so I went in and added it.