### PR TITLE
FIX: panic in ipmi bmc native collector

### DIFF
--- a/collector_bmc_native.go
+++ b/collector_bmc_native.go
@@ -60,6 +60,9 @@ func (c BMCNativeCollector) Collect(_ freeipmi.Result, ch chan<- prometheus.Metr
 	// The API looks slightly awkward here, but doing this instead of calling
 	// client.GetSystemInfo() greatly reduces the number of required round-trips.
 	systemInfo := ipmi.SystemInfoParams{
+		SetInProgress: &ipmi.SystemInfoParam_SetInProgress{
+			Value: ipmi.SetInProgress_SetComplete,
+		},
 		SystemFirmwareVersions: make([]*ipmi.SystemInfoParam_SystemFirmwareVersion, 0),
 	}
 	err = client.GetSystemInfoParamsFor(context.TODO(), &systemInfo)


### PR DESCRIPTION
When I use native-IPMI to collect BMC metrics, the ipmi-exporter always panics. The related issues are: [#262](https://github.com/prometheus-community/ipmi_exporter/issues/262) and [#248 ](https://github.com/prometheus-community/ipmi_exporter/issues/248).

error info:

``` text
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x137bc9e]

goroutine 99 [running]:
github.com/bougou/go-ipmi.(*SystemInfoParams).ToSystemInfo(0xc00053b4f8)
	/root/gotools/pkg/mod/github.com/bougou/go-ipmi@v0.7.2/types_system_info_params.go:101 +0x3e
```

The panic always occurs at github.com/bougou/go-ipmi.(*SystemInfoParams).ToSystemInfo. Looking at the corresponding code.

```go
func (systemInfoParams *SystemInfoParams) ToSystemInfo() *SystemInfo {
	systemInfo := &SystemInfo{
		SetInProgress: systemInfoParams.SetInProgress.Value,
	}

	systemInfo.SystemFirmwareVersion, _, _, _ = getSystemInfoStringMeta(convertToInterfaceSlice(systemInfoParams.SystemFirmwareVersions))
	systemInfo.SystemName, _, _, _ = getSystemInfoStringMeta(convertToInterfaceSlice(systemInfoParams.SystemNames))
	systemInfo.PrimaryOSName, _, _, _ = getSystemInfoStringMeta(convertToInterfaceSlice(systemInfoParams.PrimaryOSNames))
	systemInfo.OSName, _, _, _ = getSystemInfoStringMeta(convertToInterfaceSlice(systemInfoParams.OSNames))
	systemInfo.OSVersion, _, _, _ = getSystemInfoStringMeta(convertToInterfaceSlice(systemInfoParams.OSVersions))
	systemInfo.BMCURL, _, _, _ = getSystemInfoStringMeta(convertToInterfaceSlice(systemInfoParams.BMCURLs))
	systemInfo.ManagementURL, _, _, _ = getSystemInfoStringMeta(convertToInterfaceSlice(systemInfoParams.ManagementURLs))

	return systemInfo
}
```
The pointer `SetInProgress` in `systemInfoParams.SetInProgress.Value` might be nil. A check has already been added before usage to ensure it is not nil, avoiding a null pointer dereference.
