### PR TITLE
FIX: native ipmi client not close

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -130,7 +130,7 @@ func targetName(target string) string {
 	return target
 }
 
-func NewNativeClient(target ipmiTarget) (*ipmi.Client, error) {
+func NewNativeClient(ctx context.Context, target ipmiTarget) (*ipmi.Client, error) {
 	var client *ipmi.Client
 	var err error
 
@@ -164,9 +164,15 @@ func NewNativeClient(target ipmiTarget) (*ipmi.Client, error) {
 		client = client.WithMaxPrivilegeLevel(priv)
 	}
 	// TODO workaround-flags not used in native client
-	if err := client.Connect(context.TODO()); err != nil {
+	if err := client.Connect(ctx); err != nil {
 		logger.Error("Error connecting to IPMI device", "target", target.host, "error", err)
 		return nil, err
 	}
 	return client, nil
+}
+
+func CloseNativeClient(ctx context.Context, client *ipmi.Client) {
+	if closeErr := client.Close(ctx); closeErr != nil {
+		logger.Warn("Failed to close IPMI client", "target", client.Host, "error", closeErr)
+	}
 }

--- a/collector_bmc_native.go
+++ b/collector_bmc_native.go
@@ -48,11 +48,13 @@ func (c BMCNativeCollector) Args() []string {
 }
 
 func (c BMCNativeCollector) Collect(_ freeipmi.Result, ch chan<- prometheus.Metric, target ipmiTarget) (int, error) {
-	client, err := NewNativeClient(target)
+	ctx := context.TODO()
+	client, err := NewNativeClient(ctx, target)
 	if err != nil {
 		return 0, err
 	}
-	res, err := client.GetDeviceID(context.TODO())
+	defer CloseNativeClient(ctx, client)
+	res, err := client.GetDeviceID(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -65,7 +67,7 @@ func (c BMCNativeCollector) Collect(_ freeipmi.Result, ch chan<- prometheus.Metr
 		},
 		SystemFirmwareVersions: make([]*ipmi.SystemInfoParam_SystemFirmwareVersion, 0),
 	}
-	err = client.GetSystemInfoParamsFor(context.TODO(), &systemInfo)
+	err = client.GetSystemInfoParamsFor(ctx, &systemInfo)
 	// This one is not always available
 	systemFirmwareVersion := "N/A"
 	if err != nil {

--- a/collector_bmc_watchdog_native.go
+++ b/collector_bmc_watchdog_native.go
@@ -95,11 +95,13 @@ func (c BMCWatchdogNativeCollector) Collect(_ freeipmi.Result, ch chan<- prometh
 
 	// TODO this now works remotely
 
-	client, err := NewNativeClient(target)
+	ctx := context.TODO()
+	client, err := NewNativeClient(ctx, target)
 	if err != nil {
 		return 0, err
 	}
-	res, err := client.GetWatchdogTimer(context.TODO())
+	defer CloseNativeClient(ctx, client)
+	res, err := client.GetWatchdogTimer(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/collector_chassis_native.go
+++ b/collector_chassis_native.go
@@ -58,11 +58,13 @@ func (c ChassisNativeCollector) Args() []string {
 }
 
 func (c ChassisNativeCollector) Collect(_ freeipmi.Result, ch chan<- prometheus.Metric, target ipmiTarget) (int, error) {
-	client, err := NewNativeClient(target)
+	ctx := context.TODO()
+	client, err := NewNativeClient(ctx, target)
 	if err != nil {
 		return 0, err
 	}
-	res, err := client.GetChassisStatus(context.TODO())
+	defer CloseNativeClient(ctx, client)
+	res, err := client.GetChassisStatus(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/collector_dcmi_native.go
+++ b/collector_dcmi_native.go
@@ -46,11 +46,13 @@ func (c DCMINativeCollector) Args() []string {
 }
 
 func (c DCMINativeCollector) Collect(_ freeipmi.Result, ch chan<- prometheus.Metric, target ipmiTarget) (int, error) {
-	client, err := NewNativeClient(target)
+	ctx := context.TODO()
+	client, err := NewNativeClient(ctx, target)
 	if err != nil {
 		return 0, err
 	}
-	res, err := client.GetDCMIPowerReading(context.TODO())
+	defer CloseNativeClient(ctx, client)
+	res, err := client.GetDCMIPowerReading(ctx)
 	if err != nil {
 		logger.Error("Failed to collect DCMI data", "target", targetName(target.host), "error", err)
 		return 0, err

--- a/collector_ipmi_native.go
+++ b/collector_ipmi_native.go
@@ -146,11 +146,13 @@ func (c IPMINativeCollector) Collect(_ freeipmi.Result, ch chan<- prometheus.Met
 		return true
 	}
 
-	client, err := NewNativeClient(target)
+	ctx := context.TODO()
+	client, err := NewNativeClient(ctx, target)
 	if err != nil {
 		return 0, err
 	}
-	res, err := client.GetSensors(context.TODO(), filter)
+	defer CloseNativeClient(ctx, client)
+	res, err := client.GetSensors(ctx, filter)
 	if err != nil {
 		return 0, err
 	}

--- a/collector_sel_events_native.go
+++ b/collector_sel_events_native.go
@@ -60,11 +60,13 @@ func (c SELEventsNativeCollector) Args() []string {
 func (c SELEventsNativeCollector) Collect(_ freeipmi.Result, ch chan<- prometheus.Metric, target ipmiTarget) (int, error) {
 	selEventConfigs := target.config.SELEvents
 
-	client, err := NewNativeClient(target)
+	ctx := context.TODO()
+	client, err := NewNativeClient(ctx, target)
 	if err != nil {
 		return 0, err
 	}
-	res, err := client.GetSELEntries(context.TODO(), 0)
+	defer CloseNativeClient(ctx, client)
+	res, err := client.GetSELEntries(ctx, 0)
 	if err != nil {
 		return 0, err
 	}

--- a/collector_sel_native.go
+++ b/collector_sel_native.go
@@ -53,11 +53,13 @@ func (c SELNativeCollector) Args() []string {
 }
 
 func (c SELNativeCollector) Collect(_ freeipmi.Result, ch chan<- prometheus.Metric, target ipmiTarget) (int, error) {
-	client, err := NewNativeClient(target)
+	ctx := context.TODO()
+	client, err := NewNativeClient(ctx, target)
 	if err != nil {
 		return 0, err
 	}
-	res, err := client.GetSELInfo(context.TODO())
+	defer CloseNativeClient(ctx, client)
+	res, err := client.GetSELInfo(ctx)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
### Problem Description
In issue #243, the exporter reports an error: `can't connect to ipmi collector.` Additionally, when using ipmitool, there is a "BMC busy" error. After waiting for 5-10 minutes and running the command:
```shell
ipmitool -H <targetIP> -U <user> -P <password> -Ilanplus session info active
```
it was observed that the number of active sessions continues to increase during the collection process. This suggests that some sessions are not being properly closed.

### How to Fix
In the `ipmi-native` code, the `client` is not being closed properly. If collection continues without closing the client, it can lead to resource leaks. 

After using the `NewNativeClient`, the client should be explicitly closed.