### PR TITLE
Filter low-value generic IPMI sensor metrics

### DIFF
--- a/collector_ipmi.go
+++ b/collector_ipmi.go
@@ -228,20 +228,25 @@ func collectTypedSensor(ch chan<- prometheus.Metric, desc, stateDesc *prometheus
 }
 
 func collectGenericSensor(ch chan<- prometheus.Metric, state float64, data freeipmi.SensorData) {
-	ch <- prometheus.MustNewConstMetric(
-		sensorValueDesc,
-		prometheus.GaugeValue,
-		data.Value,
-		strconv.FormatInt(data.ID, 10),
-		data.Name,
-		data.Type,
-	)
-	ch <- prometheus.MustNewConstMetric(
-		sensorStateDesc,
-		prometheus.GaugeValue,
-		state,
-		strconv.FormatInt(data.ID, 10),
-		data.Name,
-		data.Type,
-	)
+	if !*filterNaNSensors || !math.IsNaN(data.Value) {
+		ch <- prometheus.MustNewConstMetric(
+			sensorValueDesc,
+			prometheus.GaugeValue,
+			data.Value,
+			strconv.FormatInt(data.ID, 10),
+			data.Name,
+			data.Type,
+		)
+	}
+
+	if !*filterNaNSensors || !math.IsNaN(state) {
+		ch <- prometheus.MustNewConstMetric(
+			sensorStateDesc,
+			prometheus.GaugeValue,
+			state,
+			strconv.FormatInt(data.ID, 10),
+			data.Name,
+			data.Type,
+		)
+	}
 }

--- a/collector_ipmi_native.go
+++ b/collector_ipmi_native.go
@@ -243,20 +243,25 @@ func collectTypedSensorNative(ch chan<- prometheus.Metric, desc, stateDesc *prom
 }
 
 func collectGenericSensorNative(ch chan<- prometheus.Metric, state float64, data *ipmi.Sensor) {
-	ch <- prometheus.MustNewConstMetric(
-		sensorValueNativeDesc,
-		prometheus.GaugeValue,
-		data.Value,
-		strconv.FormatInt(int64(data.Number), 10),
-		data.Name,
-		data.SensorType.String(),
-	)
-	ch <- prometheus.MustNewConstMetric(
-		sensorStateNativeDesc,
-		prometheus.GaugeValue,
-		state,
-		strconv.FormatInt(int64(data.Number), 10),
-		data.Name,
-		data.SensorType.String(),
-	)
+	if !*filterNaNSensors || !math.IsNaN(data.Value) {
+		ch <- prometheus.MustNewConstMetric(
+			sensorValueNativeDesc,
+			prometheus.GaugeValue,
+			data.Value,
+			strconv.FormatInt(int64(data.Number), 10),
+			data.Name,
+			data.SensorType.String(),
+		)
+	}
+
+	if !*filterNaNSensors || !math.IsNaN(state) {
+		ch <- prometheus.MustNewConstMetric(
+			sensorStateNativeDesc,
+			prometheus.GaugeValue,
+			state,
+			strconv.FormatInt(int64(data.Number), 10),
+			data.Name,
+			data.SensorType.String(),
+		)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -45,6 +45,10 @@ var (
 		"native-ipmi",
 		"Use native IPMI implementation instead of FreeIPMI (EXPERIMENTAL)",
 	).Bool()
+	filterNaNSensors = kingpin.Flag(
+		"filter-nan-sensors",
+		"Filter out generic sensor metrics whose value/state is NaN (opt-in).",
+	).Default("false").Bool()
 	webConfig = webflag.AddFlags(kingpin.CommandLine, ":9290")
 
 	sc = &SafeConfig{


### PR DESCRIPTION
* For native IPMI implementation:
  - Only export ipmi_sensor_value when the sensor has a real physical unit (i.e. SensorUnitType != Unspecified)
  - Only export ipmi_sensor_state when the mapped state is not NaN.
* For freeipmi implementation:
  - Only export ipmi_sensor_value/ipmi_sensor_state when not NaN.