### PR TITLE
feat: add FRU (Field Replaceable Unit) collector

### DIFF
--- a/collector_fru.go
+++ b/collector_fru.go
@@ -1,0 +1,88 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus-community/ipmi_exporter/freeipmi"
+)
+
+const (
+	FRUCollectorName CollectorName = "fru"
+)
+
+var (
+	fruInfoDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "fru", "info"),
+		"Constant metric with value '1' providing FRU (Field Replaceable Unit) information.",
+		[]string{"product_name", "product_serial", "product_manufacturer", "product_part_number", "board_product_name", "chassis_type"},
+		nil,
+	)
+)
+
+type FRUCollector struct{}
+
+func (c FRUCollector) Name() CollectorName {
+	return FRUCollectorName
+}
+
+func (c FRUCollector) Cmd() string {
+	return "ipmi-fru"
+}
+
+func (c FRUCollector) Args() []string {
+	return []string{}
+}
+
+func (c FRUCollector) Collect(result freeipmi.Result, ch chan<- prometheus.Metric, target ipmiTarget) (int, error) {
+	productName, err := freeipmi.GetFRUProductName(result)
+	if err != nil {
+		logger.Debug("Failed to parse FRU data", "target", targetName(target.host), "field", "product_name", "error", err)
+		productName = "N/A"
+	}
+	productSerial, err := freeipmi.GetFRUProductSerial(result)
+	if err != nil {
+		logger.Debug("Failed to parse FRU data", "target", targetName(target.host), "field", "product_serial", "error", err)
+		productSerial = "N/A"
+	}
+	productManufacturer, err := freeipmi.GetFRUProductManufacturer(result)
+	if err != nil {
+		logger.Debug("Failed to parse FRU data", "target", targetName(target.host), "field", "product_manufacturer", "error", err)
+		productManufacturer = "N/A"
+	}
+	productPartNumber, err := freeipmi.GetFRUProductPartNumber(result)
+	if err != nil {
+		logger.Debug("Failed to parse FRU data", "target", targetName(target.host), "field", "product_part_number", "error", err)
+		productPartNumber = "N/A"
+	}
+	boardProductName, err := freeipmi.GetFRUBoardProductName(result)
+	if err != nil {
+		logger.Debug("Failed to parse FRU data", "target", targetName(target.host), "field", "board_product_name", "error", err)
+		boardProductName = "N/A"
+	}
+	chassisType, err := freeipmi.GetFRUChassisType(result)
+	if err != nil {
+		logger.Debug("Failed to parse FRU data", "target", targetName(target.host), "field", "chassis_type", "error", err)
+		chassisType = "N/A"
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		fruInfoDesc,
+		prometheus.GaugeValue,
+		1,
+		productName, productSerial, productManufacturer, productPartNumber, boardProductName, chassisType,
+	)
+	return 1, nil
+}

--- a/config.go
+++ b/config.go
@@ -112,6 +112,8 @@ func (c CollectorName) GetInstance() (collector, error) {
 			return SMLANModeNativeCollector{}, nil
 		}
 		return SMLANModeCollector{}, nil
+	case FRUCollectorName:
+		return FRUCollector{}, nil
 	}
 	return nil, fmt.Errorf("invalid collector: %s", string(c))
 }

--- a/freeipmi/freeipmi.go
+++ b/freeipmi/freeipmi.go
@@ -53,6 +53,13 @@ var (
 	bmcWatchdogPretimeoutIntervalRegex  = regexp.MustCompile(`^Pre-Timeout Interval:\s*(?P<value>[0-9.]*)\s*seconds.*`)
 	bmcWatchdogInitialCountdownRegex    = regexp.MustCompile(`^Initial Countdown:\s*(?P<value>[0-9.]*)\s*seconds.*`)
 	bmcWatchdogCurrentCountdownRegex    = regexp.MustCompile(`^Current Countdown:\s*(?P<value>[0-9.]*)\s*seconds.*`)
+
+	fruProductNameRegex         = regexp.MustCompile(`^\s*FRU Product Name\s*:\s*(?P<value>.+)`)
+	fruProductSerialRegex       = regexp.MustCompile(`^\s*FRU Product Serial Number\s*:\s*(?P<value>.+)`)
+	fruProductManufacturerRegex = regexp.MustCompile(`^\s*FRU Product Manufacturer Name\s*:\s*(?P<value>.+)`)
+	fruProductPartNumberRegex   = regexp.MustCompile(`^\s*FRU Product Part/Model Number\s*:\s*(?P<value>.+)`)
+	fruBoardProductNameRegex    = regexp.MustCompile(`^\s*FRU Board Product Name\s*:\s*(?P<value>.+)`)
+	fruChassisTypeRegex         = regexp.MustCompile(`^\s*FRU Chassis Type\s*:\s*(?P<value>.+)`)
 )
 
 // Result represents the outcome of a call to one of the FreeIPMI tools.
@@ -472,4 +479,64 @@ func GetSELEvents(ipmiOutput Result) ([]SELEventData, error) {
 		})
 	}
 	return events, nil
+}
+
+func GetFRUProductName(ipmiOutput Result) (string, error) {
+	value, err := getValue(ipmiOutput.output, fruProductNameRegex)
+	if err != nil {
+		if ipmiOutput.err != nil {
+			return "", fmt.Errorf("%s: %s", ipmiOutput.err, ipmiOutput.output)
+		}
+	}
+	return strings.TrimSpace(value), err
+}
+
+func GetFRUProductSerial(ipmiOutput Result) (string, error) {
+	value, err := getValue(ipmiOutput.output, fruProductSerialRegex)
+	if err != nil {
+		if ipmiOutput.err != nil {
+			return "", fmt.Errorf("%s: %s", ipmiOutput.err, ipmiOutput.output)
+		}
+	}
+	return strings.TrimSpace(value), err
+}
+
+func GetFRUProductManufacturer(ipmiOutput Result) (string, error) {
+	value, err := getValue(ipmiOutput.output, fruProductManufacturerRegex)
+	if err != nil {
+		if ipmiOutput.err != nil {
+			return "", fmt.Errorf("%s: %s", ipmiOutput.err, ipmiOutput.output)
+		}
+	}
+	return strings.TrimSpace(value), err
+}
+
+func GetFRUProductPartNumber(ipmiOutput Result) (string, error) {
+	value, err := getValue(ipmiOutput.output, fruProductPartNumberRegex)
+	if err != nil {
+		if ipmiOutput.err != nil {
+			return "", fmt.Errorf("%s: %s", ipmiOutput.err, ipmiOutput.output)
+		}
+	}
+	return strings.TrimSpace(value), err
+}
+
+func GetFRUBoardProductName(ipmiOutput Result) (string, error) {
+	value, err := getValue(ipmiOutput.output, fruBoardProductNameRegex)
+	if err != nil {
+		if ipmiOutput.err != nil {
+			return "", fmt.Errorf("%s: %s", ipmiOutput.err, ipmiOutput.output)
+		}
+	}
+	return strings.TrimSpace(value), err
+}
+
+func GetFRUChassisType(ipmiOutput Result) (string, error) {
+	value, err := getValue(ipmiOutput.output, fruChassisTypeRegex)
+	if err != nil {
+		if ipmiOutput.err != nil {
+			return "", fmt.Errorf("%s: %s", ipmiOutput.err, ipmiOutput.output)
+		}
+	}
+	return strings.TrimSpace(value), err
 }


### PR DESCRIPTION
## Summary

Adds a new `ipmi-fru` collector that exposes hardware inventory data as the `ipmi_fru_info` Prometheus metric.

Closes #127

## What this implements

- New `collector_fru.go` following the existing `collector_bmc.go` pattern
- 6 FRU regex patterns + getter functions in `freeipmi/freeipmi.go`
- Registration in `config.go` via `GetInstance()` switch
- Labels: `product_name`, `product_serial`, `product_manufacturer`, `product_part_number`, `board_product_name`, `chassis_type`
- Graceful degradation: missing fields return `N/A`, never errors
- Opt-in via config (not added to default collectors list)

## What is NOT included from #127

This is the **core implementation**. The following items from the original request are left as follow-up work:

- Per-device FRU entries (PSUs, backplanes, NICs, RAID controllers) -- currently only parses the first/system board entry
- PSU wattage/capacity parsing (rated watts for capacity alerting)
- Manufacturing dates
- DC output specifications
- Native IPMI implementation (`collector_fru_native.go`)

These can each be added incrementally in future PRs.

## Tested on

- **Hardware:** Dell PowerEdge R730
- **OS:** RHEL 9.5
- **FreeIPMI:** 1.6.14
- **Go:** 1.24.2

```
# HELP ipmi_fru_info Constant metric with value 1 providing FRU information.
# TYPE ipmi_fru_info gauge
ipmi_fru_info{board_product_name="PowerEdge R730",chassis_type="N/A",product_manufacturer="DELL",product_name="PowerEdge R730",product_part_number="",product_serial="H804B42"} 1
ipmi_up{collector="fru"} 1
```

## Example config

```yaml
modules:
  default:
    collectors:
      - bmc
      - ipmi
      - chassis
      - fru
```

Signed-off-by: Zayden R <Zayden-R@users.noreply.github.com>